### PR TITLE
Add a constructor for `Bijection` that accepts an `AbstractDict` as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ and values are of `Any` type.
 * `b = Bijection(x,y)`: This gives a new `Bijection` in which the keys
   are type `typeof(x)`, the values are type `typeof(y)` and the
   key-value pair `(x,y)` is inserted into the `Bijection`.
+  
+* `b = Bijection(dict::AbstractDict{S, T})`: This gives a new `Bijection` in which the keys
+  are type `S`, the values are type `T` and all
+  key-value pairs in `dict` are inserted into the `Bijection`.
 
 ## Adding and deleting pairs
 

--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -44,6 +44,15 @@ function Bijection(x::S, y::T) where {S,T}
     return b
 end
 
+# Convert an `AbstractDict` to a `Bijection`
+function Bijection(dict::AbstractDict{S, T}) where S where T
+    b = Bijection{S,T}()
+    for (k, v) in pairs(dict)
+        b[k] = v
+    return b
+end
+Bijection(b::Bijection) = b
+
 # Decent way to print out a bijection
 function show(io::IO,b::Bijection{S,T}) where {S,T}
     print(io,"Bijection{$S,$T} (with $(length(b)) pairs)")

--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -49,6 +49,7 @@ function Bijection(dict::AbstractDict{S, T}) where S where T
     b = Bijection{S,T}()
     for (k, v) in pairs(dict)
         b[k] = v
+    end
     return b
 end
 Bijection(b::Bijection) = b


### PR DESCRIPTION
This pull request adds a constructor for `Bijection` that accepts an `AbstractDict` as input.

Before this pull request:
```julia
julia> dict = Dict{String, Int}()
Dict{String,Int64}()

julia> dict["a"] = 1
1

julia> dict["b"] = 2
2

julia> b = Bijection(dict)
ERROR: MethodError: no method matching Bijection(::Dict{String,Int64})
```

After this pull request:
```julia
julia> dict = Dict{String, Int}()
Dict{String,Int64}()

julia> dict["a"] = 1
1

julia> dict["b"] = 2
2

julia> b = Bijection(dict)
Bijection{String,Int64} (with 2 pairs)
julia> typeof(b)
Bijection{String,Int64}

julia> collect(keys(b))
2-element Vector{String}:
 "b"
 "a"

julia> collect(values(b))
2-element Vector{Int64}:
 2
 1
```

cc: @scheinerman 