### PR TITLE
Add `get(b::Bijection, key, default)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.2"
 [compat]
 julia = "1"
 
-
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -1,6 +1,6 @@
 module Bijections
 
-import Base: delete!, length, isempty, collect, setindex!, getindex
+import Base: delete!, length, isempty, collect, setindex!, getindex, get
 import Base: show, display, ==, iterate
 
 # import Base.isempty, Base.collect, Base.setindex!, Base.getindex
@@ -161,6 +161,13 @@ iterate(b::Bijection{S,T}) where {S,T} = iterate(b.f)
 Dict(b::Bijection) = copy(b.f)
 
 
+# Check if this bijection is empty
+"""
+`get(b::Bijection, key, default)` returns b[key] if it exists and returns default otherwise.
+"""
+function get(b::Bijection, key, default)
+    get(b.f, key, default)
+end
 
 include("inversion.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,9 @@ using Bijections
 b = Bijection(3,"Hello")
 @test b[3] == "Hello"
 @test b("Hello") == 3
+@test haskey(b, 3)
+@test !haskey(b, 4)
+@test !haskey(b, "Hello")
 
 b[2] = "Bye"
 @test b[2] == "Bye"


### PR DESCRIPTION
Hi,

This pull request adds `get(b::Bijection, key, default)` in order to enable `haskey(b::Bijection, key)`. Please see the testing code I added for examples.

Best,