### PR TITLE
Remove display overload

### DIFF
--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -93,8 +93,6 @@ function show(io::IO, b::Bijection{S,T}) where {S,T}
     print(io, "Bijection{$S,$T} (with $(length(b)) pairs)")
 end
 
-display(b::Bijection) = (print("Bijection "); display(b.f))
-
 # equality checking
 ==(a::Bijection, b::Bijection) = a.f == b.f
 


### PR DESCRIPTION
It's generally recommended to not overload display, instaed you overload different `show` or `show` MIME types. This is a big invalidator.