### PR TITLE
Fix warning for unqualified constructor extension

### DIFF
--- a/src/Bijections.jl
+++ b/src/Bijections.jl
@@ -185,7 +185,7 @@ iterate(b::Bijection{S,T}, s::Int) where {S,T} = iterate(b.f, s)
 iterate(b::Bijection{S,T}) where {S,T} = iterate(b.f)
 
 # convert a Bijection into a Dict; probably not useful 
-Dict(b::Bijection) = copy(b.f)
+Base.Dict(b::Bijection) = copy(b.f)
 
 
 # Check if this bijection is empty


### PR DESCRIPTION
Newer Julia versions warn about the undefined behaviour of extending a constructor (here Dict) without specifying its package (here Base).
This is fixed by fully qualifying the extended constructor, i.e. Base.Dict(b::Bijection)